### PR TITLE
[2FAuth] Add ability to edit APP_URL env variable

### DIFF
--- a/charts/stable/twofauth/questions.yaml
+++ b/charts/stable/twofauth/questions.yaml
@@ -29,6 +29,11 @@ questions:
                 schema:
                   type: string
                   default: "2FAuth"
+              - variable: url
+                label: App Url
+                schema:
+                  type: string
+                  default: "http://localhost:8000"
               - variable: session_lifetime
                 label: Session Lifetime
                 schema:


### PR DESCRIPTION
APPR_URL env variable is set to http://localhost:8000/ inside _values.yaml_, so it cannot be overwritten. The chart deploy without errors, but if you try to access the web UI after deployment, you will get a blank page and some errors in the browser's console, because the browser is trying to accesso localhost. This PR add the ability to change the value of APP_URL from the "App Configuration" section of the chart's settings.